### PR TITLE
Fix warning when including a title

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: 'The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off'
     required: false
     default: 'Info'
+  title:
+    description: 'Optional title.'
+    required: false
+    default: ''
   tag:
     description: 'Optional tag or build version.'
     required: false


### PR DESCRIPTION
Fix #4 (Unexpected input(s) 'title' warning)