### PR TITLE
Add input validation and path scope enforcement

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53,6 +53,7 @@ const core = __importStar(__nccwpck_require__(7484));
 const exec = __importStar(__nccwpck_require__(5236));
 const fs = __importStar(__nccwpck_require__(9896));
 const path = __importStar(__nccwpck_require__(6928));
+const sanitize_1 = __nccwpck_require__(1161);
 const VERSION = '5.5.4';
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -63,9 +64,10 @@ function run() {
             let toolpath = core.getInput('toolpath');
             const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
             const resolvedToolpath = path.resolve(workspace, toolpath);
-            const normalizedWorkspace = path.resolve(workspace);
-            if (resolvedToolpath !== normalizedWorkspace
-                && !resolvedToolpath.startsWith(normalizedWorkspace + path.sep)) {
+            try {
+                (0, sanitize_1.assertWithinWorkspace)(resolvedToolpath, 'toolpath', workspace);
+            }
+            catch (_a) {
                 core.setFailed(`'toolpath' resolves outside the workspace: ${resolvedToolpath}`);
                 return;
             }
@@ -128,13 +130,6 @@ function run() {
             output = '';
             resultCode = 0;
             try {
-                const assertWithinWorkspace = (resolvedPath, inputName) => {
-                    const normalizedResolved = path.resolve(resolvedPath);
-                    if (normalizedResolved !== normalizedWorkspace
-                        && !normalizedResolved.startsWith(normalizedWorkspace + path.sep)) {
-                        throw new Error(`Input '${inputName}' resolves outside the workspace: ${resolvedPath}`);
-                    }
-                };
                 const workingdir = (core.getInput('workingdir') || '').trim();
                 let targetdir = (core.getInput('targetdir') || '');
                 let historydir = (core.getInput('historydir') || '');
@@ -174,37 +169,12 @@ function run() {
                         reports = updatedReports;
                     }
                 }
-                if (targetdir.length > 0) {
-                    assertWithinWorkspace(path.resolve(workspace, targetdir), 'targetdir');
-                }
-                if (historydir.length > 0) {
-                    assertWithinWorkspace(path.resolve(workspace, historydir), 'historydir');
-                }
-                if (sourcedirs.length > 0) {
-                    sourcedirs.split(/[;]/).forEach(sourcedir => {
-                        const trimmed = sourcedir.trim();
-                        if (trimmed.length > 0) {
-                            assertWithinWorkspace(path.resolve(workspace, trimmed), 'sourcedirs');
-                        }
-                    });
-                }
-                if (reports.length > 0) {
-                    reports.split(/[;]/).forEach(report => {
-                        const trimmed = report.trim();
-                        if (trimmed.length > 0) {
-                            assertWithinWorkspace(path.resolve(workspace, trimmed), 'reports');
-                        }
-                    });
-                }
                 const plugins = core.getInput('plugins') || '';
-                if (plugins.length > 0) {
-                    plugins.split(/[;]/).forEach(plugin => {
-                        const trimmed = plugin.trim();
-                        if (trimmed.length > 0) {
-                            assertWithinWorkspace(path.resolve(workspace, trimmed), 'plugins');
-                        }
-                    });
-                }
+                (0, sanitize_1.assertPathsWithinWorkspace)(targetdir, 'targetdir', workspace);
+                (0, sanitize_1.assertPathsWithinWorkspace)(historydir, 'historydir', workspace);
+                (0, sanitize_1.assertPathsWithinWorkspace)(sourcedirs, 'sourcedirs', workspace);
+                (0, sanitize_1.assertPathsWithinWorkspace)(reports, 'reports', workspace);
+                (0, sanitize_1.assertPathsWithinWorkspace)(plugins, 'plugins', workspace);
                 const args = [
                     '-reports:' + reports,
                     '-targetdir:' + targetdir,
@@ -225,14 +195,15 @@ function run() {
                 const customSettings = (core.getInput('customSettings') || '');
                 if (customSettings.length > 0) {
                     customSettings.split(/[,;]/).forEach(setting => {
-                        const trimmed = setting.trim();
-                        if (trimmed.length === 0)
-                            return;
-                        if (trimmed.startsWith('-') || !trimmed.includes('=')) {
-                            core.warning(`Skipping invalid custom setting: '${trimmed}'. Expected format: key=value`);
+                        const validated = (0, sanitize_1.validateCustomSetting)(setting);
+                        if (validated === null) {
+                            const trimmed = setting.trim();
+                            if (trimmed.length > 0) {
+                                core.warning(`Skipping invalid custom setting: '${trimmed}'. Expected format: key=value`);
+                            }
                             return;
                         }
-                        args.push(trimmed);
+                        args.push(validated);
                     });
                 }
                 resultCode = yield exec.exec(path.join(toolpath, 'reportgenerator'), args, {
@@ -255,6 +226,78 @@ function run() {
     });
 }
 run();
+
+
+/***/ }),
+
+/***/ 1161:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.assertWithinWorkspace = assertWithinWorkspace;
+exports.assertPathsWithinWorkspace = assertPathsWithinWorkspace;
+exports.validateCustomSetting = validateCustomSetting;
+const path = __importStar(__nccwpck_require__(6928));
+function assertWithinWorkspace(resolvedPath, inputName, workspace) {
+    const normalizedResolved = path.resolve(resolvedPath);
+    const normalizedWorkspace = path.resolve(workspace);
+    if (normalizedResolved !== normalizedWorkspace
+        && !normalizedResolved.startsWith(normalizedWorkspace + path.sep)) {
+        throw new Error(`Input '${inputName}' resolves outside the workspace: ${resolvedPath}`);
+    }
+}
+function assertPathsWithinWorkspace(value, inputName, workspace) {
+    value.split(/[;]/).forEach(segment => {
+        const trimmed = segment.trim();
+        if (trimmed.length > 0) {
+            assertWithinWorkspace(path.resolve(workspace, trimmed), inputName, workspace);
+        }
+    });
+}
+function validateCustomSetting(setting) {
+    const trimmed = setting.trim();
+    if (trimmed.length === 0)
+        return null;
+    if (trimmed.startsWith('-') || !trimmed.includes('=')) {
+        return null;
+    }
+    return trimmed;
+}
 
 
 /***/ }),

--- a/dist/index.js
+++ b/dist/index.js
@@ -61,6 +61,15 @@ function run() {
             let output = '';
             let resultCode = 0;
             let toolpath = core.getInput('toolpath');
+            const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+            const resolvedToolpath = path.resolve(workspace, toolpath);
+            const normalizedWorkspace = path.resolve(workspace);
+            if (resolvedToolpath !== normalizedWorkspace
+                && !resolvedToolpath.startsWith(normalizedWorkspace + path.sep)) {
+                core.setFailed(`'toolpath' resolves outside the workspace: ${resolvedToolpath}`);
+                return;
+            }
+            toolpath = resolvedToolpath;
             try {
                 resultCode = yield exec.exec('dotnet', ['--version'], {
                     listeners: {
@@ -119,6 +128,13 @@ function run() {
             output = '';
             resultCode = 0;
             try {
+                const assertWithinWorkspace = (resolvedPath, inputName) => {
+                    const normalizedResolved = path.resolve(resolvedPath);
+                    if (normalizedResolved !== normalizedWorkspace
+                        && !normalizedResolved.startsWith(normalizedWorkspace + path.sep)) {
+                        throw new Error(`Input '${inputName}' resolves outside the workspace: ${resolvedPath}`);
+                    }
+                };
                 const workingdir = (core.getInput('workingdir') || '').trim();
                 let targetdir = (core.getInput('targetdir') || '');
                 let historydir = (core.getInput('historydir') || '');
@@ -158,13 +174,44 @@ function run() {
                         reports = updatedReports;
                     }
                 }
+                if (targetdir.length > 0) {
+                    assertWithinWorkspace(path.resolve(workspace, targetdir), 'targetdir');
+                }
+                if (historydir.length > 0) {
+                    assertWithinWorkspace(path.resolve(workspace, historydir), 'historydir');
+                }
+                if (sourcedirs.length > 0) {
+                    sourcedirs.split(/[;]/).forEach(sourcedir => {
+                        const trimmed = sourcedir.trim();
+                        if (trimmed.length > 0) {
+                            assertWithinWorkspace(path.resolve(workspace, trimmed), 'sourcedirs');
+                        }
+                    });
+                }
+                if (reports.length > 0) {
+                    reports.split(/[;]/).forEach(report => {
+                        const trimmed = report.trim();
+                        if (trimmed.length > 0) {
+                            assertWithinWorkspace(path.resolve(workspace, trimmed), 'reports');
+                        }
+                    });
+                }
+                const plugins = core.getInput('plugins') || '';
+                if (plugins.length > 0) {
+                    plugins.split(/[;]/).forEach(plugin => {
+                        const trimmed = plugin.trim();
+                        if (trimmed.length > 0) {
+                            assertWithinWorkspace(path.resolve(workspace, trimmed), 'plugins');
+                        }
+                    });
+                }
                 const args = [
                     '-reports:' + reports,
                     '-targetdir:' + targetdir,
                     '-reporttypes:' + (core.getInput('reporttypes') || ''),
                     '-sourcedirs:' + sourcedirs,
                     '-historydir:' + historydir,
-                    '-plugins:' + (core.getInput('plugins') || ''),
+                    '-plugins:' + plugins,
                     '-assemblyfilters:' + (core.getInput('assemblyfilters') || ''),
                     '-classfilters:' + (core.getInput('classfilters') || ''),
                     '-filefilters:' + (core.getInput('filefilters') || ''),
@@ -178,10 +225,17 @@ function run() {
                 const customSettings = (core.getInput('customSettings') || '');
                 if (customSettings.length > 0) {
                     customSettings.split(/[,;]/).forEach(setting => {
-                        args.push(setting.trim());
+                        const trimmed = setting.trim();
+                        if (trimmed.length === 0)
+                            return;
+                        if (trimmed.startsWith('-') || !trimmed.includes('=')) {
+                            core.warning(`Skipping invalid custom setting: '${trimmed}'. Expected format: key=value`);
+                            return;
+                        }
+                        args.push(trimmed);
                     });
                 }
-                resultCode = yield exec.exec(toolpath + '/reportgenerator', args, {
+                resultCode = yield exec.exec(path.join(toolpath, 'reportgenerator'), args, {
                     listeners: {
                         stdout: (data) => {
                             output += data.toString();

--- a/src/reportgenerator.ts
+++ b/src/reportgenerator.ts
@@ -2,6 +2,7 @@ import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as fs from 'fs';
 import * as path from 'path';
+import { assertPathsWithinWorkspace, assertWithinWorkspace, validateCustomSetting } from './sanitize';
 
 const VERSION = '5.5.4';
 
@@ -14,9 +15,9 @@ async function run() {
     let toolpath = core.getInput('toolpath');
     const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
     const resolvedToolpath = path.resolve(workspace, toolpath);
-    const normalizedWorkspace = path.resolve(workspace);
-    if (resolvedToolpath !== normalizedWorkspace
-        && !resolvedToolpath.startsWith(normalizedWorkspace + path.sep)) {
+    try {
+      assertWithinWorkspace(resolvedToolpath, 'toolpath', workspace);
+    } catch {
       core.setFailed(`'toolpath' resolves outside the workspace: ${resolvedToolpath}`);
       return;
     }
@@ -95,14 +96,6 @@ async function run() {
     resultCode = 0;
 
     try {
-      const assertWithinWorkspace = (resolvedPath: string, inputName: string): void => {
-        const normalizedResolved = path.resolve(resolvedPath);
-        if (normalizedResolved !== normalizedWorkspace
-            && !normalizedResolved.startsWith(normalizedWorkspace + path.sep)) {
-          throw new Error(`Input '${inputName}' resolves outside the workspace: ${resolvedPath}`);
-        }
-      };
-
       const workingdir = (core.getInput('workingdir') || '').trim();
 
       let targetdir = (core.getInput('targetdir') || '');
@@ -153,38 +146,12 @@ async function run() {
         }
       }
 
-      if (targetdir.length > 0) {
-        assertWithinWorkspace(path.resolve(workspace, targetdir), 'targetdir');
-      }
-      if (historydir.length > 0) {
-        assertWithinWorkspace(path.resolve(workspace, historydir), 'historydir');
-      }
-      if (sourcedirs.length > 0) {
-        sourcedirs.split(/[;]/).forEach(sourcedir => {
-          const trimmed = sourcedir.trim();
-          if (trimmed.length > 0) {
-            assertWithinWorkspace(path.resolve(workspace, trimmed), 'sourcedirs');
-          }
-        });
-      }
-      if (reports.length > 0) {
-        reports.split(/[;]/).forEach(report => {
-          const trimmed = report.trim();
-          if (trimmed.length > 0) {
-            assertWithinWorkspace(path.resolve(workspace, trimmed), 'reports');
-          }
-        });
-      }
-
       const plugins = core.getInput('plugins') || '';
-      if (plugins.length > 0) {
-        plugins.split(/[;]/).forEach(plugin => {
-          const trimmed = plugin.trim();
-          if (trimmed.length > 0) {
-            assertWithinWorkspace(path.resolve(workspace, trimmed), 'plugins');
-          }
-        });
-      }
+      assertPathsWithinWorkspace(targetdir, 'targetdir', workspace);
+      assertPathsWithinWorkspace(historydir, 'historydir', workspace);
+      assertPathsWithinWorkspace(sourcedirs, 'sourcedirs', workspace);
+      assertPathsWithinWorkspace(reports, 'reports', workspace);
+      assertPathsWithinWorkspace(plugins, 'plugins', workspace);
 
       const args = [
         '-reports:' + reports,
@@ -208,13 +175,15 @@ async function run() {
 
       if (customSettings.length > 0) {
           customSettings.split(/[,;]/).forEach(setting => {
-              const trimmed = setting.trim();
-              if (trimmed.length === 0) return;
-              if (trimmed.startsWith('-') || !trimmed.includes('=')) {
-                core.warning(`Skipping invalid custom setting: '${trimmed}'. Expected format: key=value`);
+              const validated = validateCustomSetting(setting);
+              if (validated === null) {
+                const trimmed = setting.trim();
+                if (trimmed.length > 0) {
+                  core.warning(`Skipping invalid custom setting: '${trimmed}'. Expected format: key=value`);
+                }
                 return;
               }
-              args.push(trimmed);
+              args.push(validated);
           });
       }
 

--- a/src/reportgenerator.ts
+++ b/src/reportgenerator.ts
@@ -12,6 +12,15 @@ async function run() {
     let output = '';
     let resultCode = 0;
     let toolpath = core.getInput('toolpath');
+    const workspace = process.env.GITHUB_WORKSPACE || process.cwd();
+    const resolvedToolpath = path.resolve(workspace, toolpath);
+    const normalizedWorkspace = path.resolve(workspace);
+    if (resolvedToolpath !== normalizedWorkspace
+        && !resolvedToolpath.startsWith(normalizedWorkspace + path.sep)) {
+      core.setFailed(`'toolpath' resolves outside the workspace: ${resolvedToolpath}`);
+      return;
+    }
+    toolpath = resolvedToolpath;
 
     try {
       resultCode = await exec.exec(
@@ -86,6 +95,14 @@ async function run() {
     resultCode = 0;
 
     try {
+      const assertWithinWorkspace = (resolvedPath: string, inputName: string): void => {
+        const normalizedResolved = path.resolve(resolvedPath);
+        if (normalizedResolved !== normalizedWorkspace
+            && !normalizedResolved.startsWith(normalizedWorkspace + path.sep)) {
+          throw new Error(`Input '${inputName}' resolves outside the workspace: ${resolvedPath}`);
+        }
+      };
+
       const workingdir = (core.getInput('workingdir') || '').trim();
 
       let targetdir = (core.getInput('targetdir') || '');
@@ -136,13 +153,46 @@ async function run() {
         }
       }
 
+      if (targetdir.length > 0) {
+        assertWithinWorkspace(path.resolve(workspace, targetdir), 'targetdir');
+      }
+      if (historydir.length > 0) {
+        assertWithinWorkspace(path.resolve(workspace, historydir), 'historydir');
+      }
+      if (sourcedirs.length > 0) {
+        sourcedirs.split(/[;]/).forEach(sourcedir => {
+          const trimmed = sourcedir.trim();
+          if (trimmed.length > 0) {
+            assertWithinWorkspace(path.resolve(workspace, trimmed), 'sourcedirs');
+          }
+        });
+      }
+      if (reports.length > 0) {
+        reports.split(/[;]/).forEach(report => {
+          const trimmed = report.trim();
+          if (trimmed.length > 0) {
+            assertWithinWorkspace(path.resolve(workspace, trimmed), 'reports');
+          }
+        });
+      }
+
+      const plugins = core.getInput('plugins') || '';
+      if (plugins.length > 0) {
+        plugins.split(/[;]/).forEach(plugin => {
+          const trimmed = plugin.trim();
+          if (trimmed.length > 0) {
+            assertWithinWorkspace(path.resolve(workspace, trimmed), 'plugins');
+          }
+        });
+      }
+
       const args = [
         '-reports:' + reports,
         '-targetdir:' + targetdir,
         '-reporttypes:' + (core.getInput('reporttypes') || ''),
         '-sourcedirs:' + sourcedirs,
         '-historydir:' + historydir,
-        '-plugins:' + (core.getInput('plugins') || ''),
+        '-plugins:' + plugins,
         '-assemblyfilters:' + (core.getInput('assemblyfilters') || ''),
         '-classfilters:' + (core.getInput('classfilters') || ''),
         '-filefilters:' + (core.getInput('filefilters') || ''),
@@ -158,12 +208,18 @@ async function run() {
 
       if (customSettings.length > 0) {
           customSettings.split(/[,;]/).forEach(setting => {
-              args.push(setting.trim());
+              const trimmed = setting.trim();
+              if (trimmed.length === 0) return;
+              if (trimmed.startsWith('-') || !trimmed.includes('=')) {
+                core.warning(`Skipping invalid custom setting: '${trimmed}'. Expected format: key=value`);
+                return;
+              }
+              args.push(trimmed);
           });
       }
 
       resultCode = await exec.exec(
-        toolpath + '/reportgenerator',
+        path.join(toolpath, 'reportgenerator'),
         args,
         {
           listeners: {

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+
+export function assertWithinWorkspace(resolvedPath: string, inputName: string, workspace: string): void {
+  const normalizedResolved = path.resolve(resolvedPath);
+  const normalizedWorkspace = path.resolve(workspace);
+  if (normalizedResolved !== normalizedWorkspace
+      && !normalizedResolved.startsWith(normalizedWorkspace + path.sep)) {
+    throw new Error(`Input '${inputName}' resolves outside the workspace: ${resolvedPath}`);
+  }
+}
+
+export function assertPathsWithinWorkspace(value: string, inputName: string, workspace: string): void {
+  value.split(/[;]/).forEach(segment => {
+    const trimmed = segment.trim();
+    if (trimmed.length > 0) {
+      assertWithinWorkspace(path.resolve(workspace, trimmed), inputName, workspace);
+    }
+  });
+}
+
+export function validateCustomSetting(setting: string): string | null {
+  const trimmed = setting.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.startsWith('-') || !trimmed.includes('=')) {
+    return null;
+  }
+  return trimmed;
+}


### PR DESCRIPTION
Validate that toolpath, targetdir, historydir, sourcedirs, reports,
and plugins resolve within the GitHub workspace to prevent path
traversal. Validate customSettings entries match key=value format
to prevent argument injection. Use path.join() instead of string
concatenation for cross-platform correctness.

Addresses danielpalme/ReportGenerator-GitHub-Action#37
